### PR TITLE
Fix tornado version compatibility issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ RUN set -ex \
     && pip install pyasn1 \
     && pip install apache-airflow[crypto,celery,postgres,hive,jdbc,mysql,ssh${AIRFLOW_DEPS:+,}${AIRFLOW_DEPS}]==${AIRFLOW_VERSION} \
     && pip install 'redis>=2.10.5,<3' \
+    && pip3 install "tornado>=4.2.0,<6.0.0" \
     && if [ -n "${PYTHON_DEPS}" ]; then pip install ${PYTHON_DEPS}; fi \
     && apt-get purge --auto-remove -yqq $buildDeps \
     && apt-get autoremove -yqq --purge \


### PR DESCRIPTION
It looks like the new version of tornado drops a function imported by flower (`tornado.web.asynchronous`). The flower project has fixed the issue in the master branch, but haven't tagged a release with the fix and, since they haven't released since 2017, it might be a while before they do. Note that Astronomer had to make a [similar fix](https://github.com/astronomer/astronomer/commit/b4c66b10cd499565804df74e6bde5fd4349f00ff).